### PR TITLE
Fix for FileNotFoundError when mercurial or git is not installed

### DIFF
--- a/django_cachekiller/templatetags/cdnstaticfiles.py
+++ b/django_cachekiller/templatetags/cdnstaticfiles.py
@@ -24,7 +24,7 @@ class RepoRefCache(object):
     def _run_cmd(self, cmd):
         try:
             return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             return None
 
     def _strip_ref(self, ref):


### PR DESCRIPTION
Exception occurs when mercurial or git is not installed, subprocess.CalledProcessError exception is not raised by the subprocess.check_output() command.  [WinError 2] The system cannot find the file specified exception is raised instead. 
Django Version: 4.0.5
Python Version: 3.9.13

### Steps to reproduce

Mercurial or git is not installed
Add `django_cachekiller` to your `INSTALLED_APPS` in your `settings.py`
Then use the `cdnstatic` tag in the template

### Exception
FileNotFoundError at /
[WinError 2] The system cannot find the file specified
Request Method:	GET
Request URL:	http://localhost:8000/
Django Version:	4.0.5
Exception Type:	FileNotFoundError
Exception Value:	
[WinError 2] The system cannot find the file specified
Exception Location:	D:\Python39\lib\subprocess.py, line 1420, in _execute_child
Python Executable:	D:\Python39\python.exe
Python Version:	3.9.13

Template error:
   39 :     <link href=" {% cdnstatic 'css/style.css' %} " rel="stylesheet" />

  File "D:\Python39\lib\site-packages\django_cachekiller\templatetags\cdnstaticfiles.py", line 92, in render
    qs = 'tag=' + refcache.get_ref()
  File "D:\Python39\lib\site-packages\django_cachekiller\templatetags\cdnstaticfiles.py", line 69, in get_ref
    ref = self.get_hg_tip()
  File "D:\Python39\lib\site-packages\django_cachekiller\templatetags\cdnstaticfiles.py", line 53, in get_hg_tip
    ref = self._run_cmd(['hg', 'heads', '--template', '"{node}"'])
  File "D:\Python39\lib\site-packages\django_cachekiller\templatetags\cdnstaticfiles.py", line 26, in _run_cmd
    return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
  File "D:\Python39\lib\subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "D:\Python39\lib\subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "D:\Python39\lib\subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "D:\Python39\lib\subprocess.py", line 1420, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,

Exception Type: FileNotFoundError at /
Exception Value: [WinError 2] The system cannot find the file specified